### PR TITLE
fix: update github workflow

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,0 +1,9 @@
+{
+  "release-type": "node",
+  "include-component-in-tag": true,
+  "packages": {
+    "packages/edge-gateway-link": {
+      "package-name": "w3link-edge-gateway"
+    }
+  }
+}

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -1,0 +1,3 @@
+{
+  "packages/edge-gateway-link": "1.3.2"
+}

--- a/.github/workflows/edge-gateway-link.yml
+++ b/.github/workflows/edge-gateway-link.yml
@@ -17,11 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     name: Test
     steps:
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
         with:
-          version: 6.32.x
-      - uses: actions/setup-node@v2
+          version: 7.0.x
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'pnpm'
       - run: pnpm install
       - run: pnpm test:w3link-edge-gateway
   deploy-staging:
@@ -30,16 +33,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
         with:
-          version: 6.32.x
-      - uses: actions/setup-node@v2
+          version: 7.0.x
+      - uses: actions/setup-node@v4
         with:
+          node-version: 18
           cache: 'pnpm'
       - run: pnpm install
       - name: Publish app
-        uses: cloudflare/wrangler-action@2.0.0
+        uses: cloudflare/wrangler-action@v3
         env:
           ENV: 'staging' # inform the build process what the env is
           SENTRY_TOKEN: ${{secrets.SENTRY_TOKEN}}
@@ -73,18 +77,18 @@ jobs:
       - deploy-staging
       - changelog
     steps:
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
         with:
-          version: 6.32.x
-      - uses: actions/setup-node@v2
+          version: 7.0.x
+      - uses: actions/setup-node@v4
         with:
-          cache: 'pnpm'
-          node-version: 16
+          node-version: 18
           registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
       - run: pnpm install
       - name: Deploy
-        uses: cloudflare/wrangler-action@2.0.0
+        uses: cloudflare/wrangler-action@v3
         env:
           ENV: 'production' # inform the build process what the env is
           SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}

--- a/.github/workflows/edge-gateway-link.yml
+++ b/.github/workflows/edge-gateway-link.yml
@@ -52,17 +52,18 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     name: Changelog
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       releases_created: ${{ steps.tag-release.outputs.releases_created }}
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v3
+      - uses: googleapis/release-please-action@v4
         id: tag-release
         with:
-          path: packages/edge-gateway-link
+          config-file: .github/release-please-config.json
+          manifest-file: .github/release-please-manifest.json
           token: ${{ secrets.GITHUB_TOKEN }}
-          release-type: node
-          monorepo-tags: true
-          package-name: w3link-edge-gateway
   release:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changelog.outputs.releases_created
     name: Release


### PR DESCRIPTION
### Description

This PR updates the github workflow to use the latest version of the necessary plugins.

### Motivation

The current workflow uses outdated versions of  `release-please-action` and `cloudflare/wrangler-action`, which caused some actions to fail in the last run.

