### PR TITLE
feat: remove loki logging and rely on logpush

### DIFF
--- a/packages/edge-gateway-link/src/env.js
+++ b/packages/edge-gateway-link/src/env.js
@@ -1,7 +1,6 @@
 /* global BRANCH, VERSION, COMMITHASH, SENTRY_RELEASE */
 
 import Toucan from 'toucan-js'
-import { Logging } from '@web3-storage/worker-utils/loki'
 
 import pkg from '../package.json'
 
@@ -26,20 +25,6 @@ export function envAll (request, env, ctx) {
   env.SENTRY_RELEASE = SENTRY_RELEASE
 
   env.sentry = getSentry(request, env, ctx)
-
-  env.log = new Logging(request, ctx, {
-    // @ts-ignore TODO: url should be optional together with token
-    url: env.LOKI_URL,
-    token: env.LOKI_TOKEN,
-    debug: Boolean(env.DEBUG),
-    version: env.VERSION,
-    commit: env.COMMITHASH,
-    branch: env.BRANCH,
-    worker: 'w3s.link',
-    env: env.ENV,
-    sentry: env.sentry
-  })
-  env.log.time('request')
 }
 
 /**

--- a/packages/edge-gateway-link/src/error-handler.js
+++ b/packages/edge-gateway-link/src/error-handler.js
@@ -9,10 +9,6 @@ export function errorHandler (err, env) {
 
   const status = err.status || 500
 
-  if (env.sentry && status >= 500) {
-    env.log.error(err)
-  }
-
   return new Response(err.message || 'Server Error', {
     status,
     headers: {

--- a/packages/edge-gateway-link/src/index.js
+++ b/packages/edge-gateway-link/src/index.js
@@ -46,14 +46,8 @@ export default {
    */
   async fetch (request, env, ctx) {
     try {
-      const res = await router.handle(request, env, ctx)
-      env.log.timeEnd('request')
-      return env.log.end(res)
+      return await router.handle(request, env, ctx)
     } catch (/** @type {any} */ error) {
-      if (env.log) {
-        env.log.timeEnd('request')
-        return env.log.end(serverError(error, request, env))
-      }
       return serverError(error, request, env)
     }
   }

--- a/packages/edge-gateway-link/wrangler.toml
+++ b/packages/edge-gateway-link/wrangler.toml
@@ -4,6 +4,7 @@ main = "./dist/worker.js"
 compatibility_date = "2022-07-01"
 compatibility_flags = [ "url_standard" ]
 no_bundle = true
+logpush = true
 
 [build]
 command = "npm run build"


### PR DESCRIPTION
we're moving from Loki-based logging for workers to Logpush - enable that and remove Loki logging