### PR TITLE
feat(ucanto-server): proxy post requests

### DIFF
--- a/packages/edge-gateway-link/src/bindings.d.ts
+++ b/packages/edge-gateway-link/src/bindings.d.ts
@@ -13,6 +13,7 @@ export interface EnvInput {
   GATEWAY_HOSTNAME: string
   CSP_REPORT_URI: string
   GOODBITSLIST: KVNamespace
+  UCANTO_SERVER_URL: string
 }
 
 export interface EnvTransformed {

--- a/packages/edge-gateway-link/src/index.js
+++ b/packages/edge-gateway-link/src/index.js
@@ -18,6 +18,7 @@ const router = Router()
 
 router
   .all('*', envAll)
+  .post('*', withCorsHeaders(proxyPostRequest))
   .get('/version', withCorsHeaders(versionGet))
   .get('/ipfs/:cid', withCorsHeaders(ipfsGet))
   .get('/ipfs/:cid/*', withCorsHeaders(ipfsGet))
@@ -35,6 +36,21 @@ router
  */
 function serverError (error, request, env) {
   return addCorsHeaders(request, errorHandler(error, env))
+}
+
+/**
+ * Proxy POST requests to the UCANTO Server defined in the environment.
+ *
+ * @param {Request} request
+ * @param {import('./env').Env} env
+ * @returns {Promise<Response>}
+ */
+async function proxyPostRequest(request, env) {
+  const originRequest = new Request(request)
+  const url = new URL(request.url)
+  const targetUrl = `${env.UCANTO_SERVER_URL}${url.pathname}`
+  const response = await fetch(targetUrl, originRequest)
+  return response
 }
 
 export default {

--- a/packages/edge-gateway-link/src/index.js
+++ b/packages/edge-gateway-link/src/index.js
@@ -48,8 +48,8 @@ function serverError (error, request, env) {
 async function proxyPostRequest(request, env) {
   const originRequest = new Request(request)
   const url = new URL(request.url)
-  const targetUrl = `${env.UCANTO_SERVER_URL}${url.pathname}`
-  const response = await fetch(targetUrl, originRequest)
+  const targetUrl = new URL(url.pathname, env.UCANTO_SERVER_URL)
+  const response = await fetch(targetUrl.origin, originRequest)
   return response
 }
 

--- a/packages/edge-gateway-link/wrangler.toml
+++ b/packages/edge-gateway-link/wrangler.toml
@@ -37,6 +37,7 @@ GATEWAY_HOSTNAME = 'ipfs.w3s.link'
 CSP_REPORT_URI = 'https://csp-report-to.web3.storage'
 DEBUG = "false"
 ENV = "production"
+UCANTO_SERVER_URL = 'https://freeway.dag.haus'
 
 [[env.production.services]]
 binding = "EDGE_GATEWAY"
@@ -64,6 +65,7 @@ GATEWAY_HOSTNAME = 'ipfs-staging.w3s.link'
 CSP_REPORT_URI = 'https://staging.csp-report-to.web3.storage'
 DEBUG = "true"
 ENV = "staging"
+UCANTO_SERVER_URL = 'https://freeway-staging.dag.haus'
 
 [[env.staging.services]]
 binding = "EDGE_GATEWAY"
@@ -82,3 +84,4 @@ kv_namespaces = [
 GATEWAY_HOSTNAME = 'ipfs.localhost:8787'
 DEBUG = "true"
 ENV = "test"
+UCANTO_SERVER_URL = 'http://localhost:8000'


### PR DESCRIPTION
### Context
The Freeway Gateway will be able to handle UCAN invocations after the PR https://github.com/storacha/freeway/pull/133 gets merged. 
So we need to proxy POST requests sent to the `w3link` (edge-gateway-link) to the new UCANTO Server.

### Related Issue
- https://github.com/storacha/project-tracking/issues/212
- https://github.com/storacha/project-tracking/issues/160