### PR TITLE
fix: preflight cors + caching + new route

### DIFF
--- a/packages/edge-gateway-link/src/cors.js
+++ b/packages/edge-gateway-link/src/cors.js
@@ -42,8 +42,18 @@ export function addCorsHeaders (request, response) {
  */
 export function corsPreflightRequest (request) {
   const headers = new Headers()
-  headers.set('Access-Control-Allow-Origin', request.headers.get('origin') || '*')
+
+  const origin = request.headers.get('origin')
+  if (origin) {
+    headers.set('Access-Control-Allow-Origin', origin)
+    headers.set('Vary', 'Origin')
+  } else {
+    headers.set('Access-Control-Allow-Origin', '*')
+  }
+
   headers.set('Access-Control-Allow-Methods', 'GET, HEAD, POST, OPTIONS')
   headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+  headers.set('Access-Control-Max-Age', '86400') // Cache preflight for 24 hours
+
   return new Response(null, { headers, status: 204 })
 }

--- a/packages/edge-gateway-link/wrangler.toml
+++ b/packages/edge-gateway-link/wrangler.toml
@@ -19,6 +19,7 @@ ENV = "dev"
 # name = "w3link-edge-gateway-production"
 account_id = "fffa4b4363a7e5250af8357087263b3a" # Protocol Labs CF account
 routes = [
+  { pattern = "w3s.link/", zone_id = "ae60d8f737317467ec666dc3851a6277" },
   { pattern = "w3s.link/ipfs/*", zone_id = "ae60d8f737317467ec666dc3851a6277" },
   { pattern = "*.ipfs.w3s.link/*", zone_id = "ae60d8f737317467ec666dc3851a6277" },
   { pattern = "ipfs.w3s.link/*", zone_id = "ae60d8f737317467ec666dc3851a6277" },
@@ -50,6 +51,7 @@ environment = "production"
 # name = "gateway-nft-storage-staging"
 account_id = "fffa4b4363a7e5250af8357087263b3a" # Protocol Labs CF account
 routes = [
+  { pattern = "w3s-staging.link/", zone_id = "ae60d8f737317467ec666dc3851a6277" },
   { pattern = "*.ipfs-staging.w3s.link/*", zone_id = "ae60d8f737317467ec666dc3851a6277" },
   { pattern = "ipfs-staging.w3s.link/*", zone_id = "ae60d8f737317467ec666dc3851a6277" },
   { pattern = "*.ipfs-staging.w3s.link", zone_id = "ae60d8f737317467ec666dc3851a6277" },


### PR DESCRIPTION
### Changes
- Added `Access-Control-Max-Age` to prevent the browser from performing frequent preflight requests.
- Added `Vary: Origin` to ensure that cached responses differentiate between different origins.
- Added new routes `https://w3s.link/` and `https://w3s-staging.link/` to the workers.