### PR TITLE
feat: configure alternate gateway domains

### DIFF
--- a/packages/edge-gateway-link/wrangler.toml
+++ b/packages/edge-gateway-link/wrangler.toml
@@ -27,7 +27,15 @@ routes = [
   { pattern = "w3s.link/ipns/*", zone_id = "ae60d8f737317467ec666dc3851a6277" },
   { pattern = "*.ipns.w3s.link/*", zone_id = "ae60d8f737317467ec666dc3851a6277" },
   { pattern = "*.ipns.w3s.link", zone_id = "ae60d8f737317467ec666dc3851a6277" },
-  { pattern = "*/*", zone_id = "ae60d8f737317467ec666dc3851a6277" }
+  { pattern = "*/*", zone_id = "ae60d8f737317467ec666dc3851a6277" },
+  # storacha.link
+  { pattern = "storacha.link/", zone_id = "62829b72c60604f88de28efe01a82edf" },
+  { pattern = "storacha.link/ipfs/*", zone_id = "62829b72c60604f88de28efe01a82edf" },
+  { pattern = "*.ipfs.storacha.link/*", zone_id = "62829b72c60604f88de28efe01a82edf" },
+  { pattern = "ipfs.storacha.link/*", zone_id = "62829b72c60604f88de28efe01a82edf" },
+  { pattern = "*.ipfs.storacha.link", zone_id = "62829b72c60604f88de28efe01a82edf" },
+  # gateway.storacha.network (UCAN endpoint)
+  { pattern = "gateway.storacha.network", zone_id = "37783d6f032b78cd97ce37ab6fd42848" }
 ]
 kv_namespaces = [
   { binding = "GOODBITSLIST", id = "292616354e2a4f83b7ac13ef30d66a30" }


### PR DESCRIPTION
This PR configures the alternate gateway domains `storacha.link` and `gateway.storacha.network`.

The `storacha.link` domain was previously configured manually using the cloudflare console.

The `gateway.storacha.network` is for UCAN POST requests only - it is a different domain from `storacha.link` or `w3s.link` in order to prevent gateway authorization invocations from failing when the public access domains have been blocked.